### PR TITLE
GH-4 :: Refactor to use ContentRetriever

### DIFF
--- a/src/Kickstart.Web/Features/LandingPages/LandingPageController.cs
+++ b/src/Kickstart.Web/Features/LandingPages/LandingPageController.cs
@@ -1,9 +1,4 @@
-using System.Linq;
 using System.Threading.Tasks;
-
-using CMS.ContentEngine;
-using CMS.Websites;
-using CMS.Websites.Routing;
 
 using Kentico.Content.Web.Mvc;
 using Kentico.Content.Web.Mvc.Routing;
@@ -21,44 +16,19 @@ namespace Kickstart.Web.Features.LandingPages;
 
 public class LandingPageController : Controller
 {
-    private readonly IContentQueryExecutor contentQueryExecutor;
-    private readonly IWebPageDataContextRetriever webPageDataContextRetriever;
-    private readonly IWebsiteChannelContext webSiteChannelContext;
-    private readonly IPreferredLanguageRetriever preferredLanguageRetriever;
+    private readonly IContentRetriever contentRetriever;
 
     public LandingPageController(
-        IContentQueryExecutor contentQueryExecutor,
-        IWebPageDataContextRetriever webPageDataContextRetriever,
-        IWebsiteChannelContext webSiteChannelContext,
-        IPreferredLanguageRetriever preferredLanguageRetriever)
-    {
-        this.contentQueryExecutor = contentQueryExecutor;
-        this.webPageDataContextRetriever = webPageDataContextRetriever;
-        this.webSiteChannelContext = webSiteChannelContext;
-        this.preferredLanguageRetriever = preferredLanguageRetriever;
-    }
+        IContentRetriever contentRetriever) => this.contentRetriever = contentRetriever;
 
     public async Task<IActionResult> Index()
     {
-        var context = webPageDataContextRetriever.Retrieve();
-        var builder = new ContentItemQueryBuilder()
-                            .ForContentType(
-                                LandingPage.CONTENT_TYPE_NAME,
-                                config => config
-                                    .Where(where => where.WhereEquals(nameof(WebPageFields.WebPageItemID), context.WebPage.WebPageItemID))
-                                    .WithLinkedItems(1)
-                                    .ForWebsite(webSiteChannelContext.WebsiteChannelName)
-                                )
-                            .InLanguage(preferredLanguageRetriever.Get());
-
-        var queryExecutorOptions = new ContentQueryExecutionOptions
+        var parameters = new RetrieveCurrentPageParameters
         {
-            ForPreview = webSiteChannelContext.IsPreview
+            LinkedItemsMaxLevel = 1
         };
-
-        var pages = await contentQueryExecutor.GetMappedWebPageResult<LandingPage>(builder, queryExecutorOptions);
-
-        var model = LandingPageViewModel.GetViewModel(pages.FirstOrDefault());
+        var page = await contentRetriever.RetrieveCurrentPage<LandingPage>(parameters);
+        var model = LandingPageViewModel.GetViewModel(page);
         return new TemplateResult(model);
     }
 }

--- a/src/Kickstart.Web/Features/Navigation/NavigationMenuViewComponent.cs
+++ b/src/Kickstart.Web/Features/Navigation/NavigationMenuViewComponent.cs
@@ -1,10 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 
-using CMS.ContentEngine;
-using CMS.Websites.Routing;
-
-using Kentico.Content.Web.Mvc.Routing;
+using Kentico.Content.Web.Mvc;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,20 +9,14 @@ namespace Kickstart.Web.Features.Navigation;
 
 public class NavigationMenuViewComponent : ViewComponent
 {
-    private readonly IContentQueryExecutor contentQueryExecutor;
-    private readonly IPreferredLanguageRetriever preferredLanguageRetriever;
-    private readonly IWebsiteChannelContext webSiteChannelContext;
+    private readonly IContentRetriever contentRetriever;
     private readonly INavigationService navigationService;
 
     public NavigationMenuViewComponent(
-        IContentQueryExecutor contentQueryExecutor,
-        IPreferredLanguageRetriever preferredLanguageRetriever,
-        IWebsiteChannelContext webSiteChannelContext,
+        IContentRetriever contentRetriever,
         INavigationService navigationService)
     {
-        this.contentQueryExecutor = contentQueryExecutor;
-        this.preferredLanguageRetriever = preferredLanguageRetriever;
-        this.webSiteChannelContext = webSiteChannelContext;
+        this.contentRetriever = contentRetriever;
         this.navigationService = navigationService;
     }
 
@@ -45,21 +36,17 @@ public class NavigationMenuViewComponent : ViewComponent
 
     private async Task<NavigationMenu> RetrieveMenu(string navigationMenuCodeName)
     {
-        var builder = new ContentItemQueryBuilder()
-            .ForContentType(NavigationMenu.CONTENT_TYPE_NAME,
-                config => config
-                    .Where(where => where.WhereEquals(nameof(NavigationMenu.NavigationMenuCodeName), navigationMenuCodeName))
-                    .WithLinkedItems(2, options => options.IncludeWebPageData(true)))
-            .InLanguage(preferredLanguageRetriever.Get());
-
-
-        var queryExecutorOptions = new ContentQueryExecutionOptions
+        var parameters = new RetrieveContentParameters
         {
-            ForPreview = webSiteChannelContext.IsPreview
+            LinkedItemsMaxLevel = 2
         };
+        var menus = await contentRetriever.RetrieveContent<NavigationMenu>(
+            parameters,
+            query => query
+                .Where(where => where.WhereEquals(nameof(NavigationMenu.NavigationMenuCodeName), navigationMenuCodeName)),
+            RetrievalCacheSettings.CacheDisabled
+            );
 
-        var items = await contentQueryExecutor.GetMappedResult<NavigationMenu>(builder, queryExecutorOptions);
-
-        return items.FirstOrDefault();
+        return menus.FirstOrDefault();
     }
 }


### PR DESCRIPTION
# Motivation

Fixes #GH-4

Using the recommended [Content Retriever API](https://docs.kentico.com/documentation/developers-and-admins/api/content-item-api/reference-content-retriever-api) methods rather than the old [Content Item Query](https://docs.kentico.com/documentation/developers-and-admins/api/content-item-api/reference-content-item-query) to retrieve content. 